### PR TITLE
Updated POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,13 +14,14 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <groupId>org.mybatis</groupId>
     <artifactId>mybatis-parent</artifactId>
-    <version>21</version>
+    <version>22-SNAPSHOT</version>
   </parent>
 
   <groupId>org.mybatis.caches</groupId>
@@ -28,7 +29,7 @@
   <version>1.0.1-SNAPSHOT</version>
   <packaging>jar</packaging>
 
-  <name>MyBatis Caches :: Memcached</name>
+  <name>mybatis-memcached</name>
   <description>Memcached support for MyBatis Cache</description>
   <url>http://www.mybatis.org/caches/memcached/</url>
 
@@ -65,7 +66,7 @@
     <dependency>
       <groupId>org.mybatis</groupId>
       <artifactId>mybatis</artifactId>
-      <version>3.2.6</version>
+      <version>3.2.7</version>
       <scope>provided</scope>
     </dependency>
 
@@ -75,7 +76,7 @@
     <dependency>
       <groupId>net.spy</groupId>
       <artifactId>spymemcached</artifactId>
-      <version>2.10.6</version>
+      <version>2.11.4</version>
       <scope>compile</scope>
     </dependency>
 
@@ -85,7 +86,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.10</version>
+      <version>4.11</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Use correct XSD for maven
Update to mybatis-parent 22-SNAPSHOT
Change <name> to match <artifactId> so it works properly with myEclipse
Updated mybatis to 3.2.7
Updated spymemcached to 2.11.4
Updated junit to 4.11
