### PR TITLE
Optimistic lock approach to ensure sync. over group values

### DIFF
--- a/src/main/java/org/mybatis/caches/memcached/MemcachedClientWrapper.java
+++ b/src/main/java/org/mybatis/caches/memcached/MemcachedClientWrapper.java
@@ -19,9 +19,13 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
+import net.spy.memcached.CASResponse;
+import net.spy.memcached.CASValue;
 import net.spy.memcached.MemcachedClient;
+import net.spy.memcached.internal.OperationFuture;
 
 import org.apache.ibatis.cache.CacheException;
 import org.apache.ibatis.logging.Log;
@@ -40,6 +44,39 @@ final class MemcachedClientWrapper {
     private final MemcachedConfiguration configuration;
 
     private final MemcachedClient client;
+
+	/**
+	 * Used to represent an object retrieved from Memcached along with its CAS information
+	 * 
+	 * @author Weisz, Gustavo E.
+	 */
+	private class ObjectWithCas {
+
+		Object object;
+		long cas;
+
+		ObjectWithCas(Object object, long cas) {
+			this.setObject(object);
+			this.setCas(cas);
+		}
+
+		public Object getObject() {
+			return object;
+		}
+
+		public void setObject(Object object) {
+			this.object = object;
+		}
+
+		public long getCas() {
+			return cas;
+		}
+
+		public void setCas(long cas) {
+			this.cas = cas;
+		}
+
+	}
 
     public MemcachedClientWrapper() {
         configuration = MemcachedConfigurationBuilder.getInstance().parseConfiguration();
@@ -95,46 +132,38 @@ final class MemcachedClientWrapper {
         return ret;
     }
 
-    /**
-     * Return the stored group in Memcached identified by the specified key.
-     *
-     * @param groupKey the group key.
-     * @return the group if was previously stored, null otherwise.
-     */
-    @SuppressWarnings("unchecked")
-    private Set<String> getGroup(String groupKey) {
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Retrieving group with id '"
-                    + groupKey
-                    + "'");
-        }
+	/**
+	 * Return the stored group in Memcached identified by the specified key.
+	 *
+	 * @param groupKey
+	 *            the group key.
+	 * @return the group if was previously stored, null otherwise.
+	 */
+	private ObjectWithCas getGroup(String groupKey) {
+		if (LOG.isDebugEnabled()) {
+			LOG.debug("Retrieving group with id '" + groupKey + "'");
+		}
 
-        Object groups = null;
-        try {
-            groups = retrieve(groupKey);
-        } catch (Exception e) {
-            LOG.error("Impossible to retrieve group '"
-                    + groupKey
-                    + "' see nested exceptions", e);
-        }
+		ObjectWithCas groups = null;
+		try {
+			groups = retrieveWithCas(groupKey);
+		} catch (Exception e) {
+			LOG.error("Impossible to retrieve group '" + groupKey + "' see nested exceptions", e);
+		}
 
-        if (groups == null) {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Group '"
-                        + groupKey
-                        + "' not previously stored");
-            }
-            return new HashSet<String>();
-        }
+		if (groups == null) {
+			if (LOG.isDebugEnabled()) {
+				LOG.debug("Group '" + groupKey + "' not previously stored");
+			}
+			return null;
+		}
 
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("retrieved group '"
-                    + groupKey
-                    + "' with values "
-                    + groups);
-        }
-        return (Set<String>) groups;
-    }
+		if (LOG.isDebugEnabled()) {
+			LOG.debug("retrieved group '" + groupKey + "' with values " + groups);
+		}
+
+		return groups;
+	}
 
     /**
      *
@@ -171,7 +200,47 @@ final class MemcachedClientWrapper {
         return retrieved;
     }
 
-    public void putObject(Object key, Object value, String id) {
+	/**
+	 * Retrieves an object along with its cas using the given key
+	 * 
+	 * @param keyString
+	 * @return
+	 * @throws Exception
+	 */
+	private ObjectWithCas retrieveWithCas(final String keyString) {
+		CASValue<Object> retrieved = null;
+
+		if (configuration.isUsingAsyncGet()) {
+			Future<CASValue<Object>> future;
+			if (configuration.isCompressionEnabled()) {
+				future = client.asyncGets(keyString, new CompressorTranscoder());
+			} else {
+				future = client.asyncGets(keyString);
+			}
+
+			try {
+				retrieved = future.get(configuration.getTimeout(), configuration.getTimeUnit());
+			} catch (Exception e) {
+				future.cancel(false);
+				throw new CacheException(e);
+			}
+		} else {
+			if (configuration.isCompressionEnabled()) {
+				retrieved = client.gets(keyString, new CompressorTranscoder());
+			} else {
+				retrieved = client.gets(keyString);
+			}
+		}
+
+		if (retrieved == null) {
+			return null;
+		}
+
+		return new ObjectWithCas(retrieved.getValue(), retrieved.getCas());
+	}
+
+    @SuppressWarnings("unchecked")
+	public void putObject(Object key, Object value, String id) {
         String keyString = toKeyString(key);
         String groupKey = toKeyString(id);
 
@@ -186,18 +255,29 @@ final class MemcachedClientWrapper {
         storeInMemcached(keyString, value);
 
         // add namespace key into memcached
-        Set<String> group = getGroup(groupKey);
-        group.add(keyString);
+        // Optimistic lock approach...
+ 		boolean jobDone = false;
 
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Insert/Updating object ("
-                    + groupKey
-                    + ", "
-                    + group
-                    + ")");
-        }
+ 		while (!jobDone) {
+ 			ObjectWithCas group = getGroup(groupKey);
+ 			Set<String> groupValues;
 
-        storeInMemcached(groupKey, group);
+ 			if (group == null || group.getObject() == null) {
+ 				groupValues = new HashSet<String>();
+ 				groupValues.add(keyString);
+
+ 				if (LOG.isDebugEnabled()) {
+ 					LOG.debug("Insert/Updating object (" + groupKey + ", " + groupValues + ")");
+ 				}
+
+ 				jobDone = tryToAdd(groupKey, groupValues);
+ 			} else {
+ 				groupValues = (Set<String>) group.getObject();
+ 				groupValues.add(keyString);
+
+ 				jobDone = storeInMemcached(groupKey, group);
+ 			}
+ 		}
     }
 
     /**
@@ -221,6 +301,65 @@ final class MemcachedClientWrapper {
         }
     }
 
+	/**
+	 * Tries to update an object value in memcached considering the cas validation
+	 * 
+	 * Returns true if the object passed the cas validation and was modified.
+	 * 
+	 * @param keyString
+	 * @param value
+	 * @return
+	 */
+	private boolean storeInMemcached(String keyString, ObjectWithCas value) {
+		if (value != null && value.getObject() != null && !Serializable.class.isAssignableFrom(value.getObject().getClass())) {
+			throw new CacheException("Object of type '" + value.getObject().getClass().getName() + "' that's non-serializable is not supported by Memcached");
+		}
+
+		CASResponse response;
+
+		if (configuration.isCompressionEnabled()) {
+			response = client.cas(keyString, value.getCas(), value.getObject(), new CompressorTranscoder());
+		} else {
+			response = client.cas(keyString, value.getCas(), value.getObject());
+		}
+
+		return (response.equals(CASResponse.OBSERVE_MODIFIED) || response.equals(CASResponse.OK));
+	}
+
+	/**
+	 * Tries to store an object identified by a key in Memcached.
+	 * 
+	 * Will fail if the object already exists.
+	 * 
+	 * @param keyString
+	 * @param value
+	 * @return
+	 */
+	private boolean tryToAdd(String keyString, Object value) {
+		if (value != null && !Serializable.class.isAssignableFrom(value.getClass())) {
+			throw new CacheException("Object of type '" + value.getClass().getName() + "' that's non-serializable is not supported by Memcached");
+		}
+
+		boolean done;
+		OperationFuture<Boolean> result;
+
+		if (configuration.isCompressionEnabled()) {
+			result = client.add(keyString, configuration.getExpiration(), value, new CompressorTranscoder());
+		} else {
+			result = client.add(keyString, configuration.getExpiration(), value);
+		}
+
+		try {
+			done = result.get();
+		} catch (InterruptedException e) {
+			done = false;
+		} catch (ExecutionException e) {
+			done = false;
+		}
+
+		return done;
+	}
+
     public Object removeObject(Object key) {
         String keyString = toKeyString(key);
 
@@ -237,34 +376,36 @@ final class MemcachedClientWrapper {
         return result;
     }
 
-    public void removeGroup(String id) {
-        String groupKey = toKeyString(id);
+    @SuppressWarnings("unchecked")
+	public void removeGroup(String id) {
+		String groupKey = toKeyString(id);
 
-        Set<String> group = getGroup(groupKey);
+		ObjectWithCas group = getGroup(groupKey);
+		Set<String> groupValues;
 
-        if (group == null) {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("No need to flush cached entries for group '"
-                        + id
-                        + "' because is empty");
-            }
-            return;
-        }
+		if (group == null || group.getObject() == null) {
+			if (LOG.isDebugEnabled()) {
+				LOG.debug("No need to flush cached entries for group '" + id + "' because is empty");
+			}
+			return;
+		}
 
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Flushing keys: " + group);
-        }
+		if (LOG.isDebugEnabled()) {
+			LOG.debug("Flushing keys: " + group);
+		}
 
-        for (String key : group) {
-            client.delete(key);
-        }
+		groupValues = (Set<String>) group.getObject();
 
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Flushing group: " + groupKey);
-        }
+		for (String key : groupValues) {
+			client.delete(key);
+		}
 
-        client.delete(groupKey);
-    }
+		if (LOG.isDebugEnabled()) {
+			LOG.debug("Flushing group: " + groupKey);
+		}
+
+		client.delete(groupKey);
+	}
 
     @Override
     protected void finalize() throws Throwable {

--- a/src/test/java/org/mybatis/caches/memcached/GroupTestThread.java
+++ b/src/test/java/org/mybatis/caches/memcached/GroupTestThread.java
@@ -1,0 +1,67 @@
+/**
+ *    Copyright 2012-2015 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.caches.memcached;
+
+import java.util.Random;
+import java.util.UUID;
+
+/**
+ * Thread to test race conditions behavior
+ * 
+ * @author Weisz, Gustavo E.
+ */
+public class GroupTestThread extends Thread {
+
+	private long itemsToCreate;
+	private MemcachedCache cache;
+
+	public GroupTestThread(MemcachedCache cache, long itemsToCreate) {
+		this.setCache(cache);
+		this.setItemsToCreate(itemsToCreate);
+	}
+
+	public long getItemsToCreate() {
+		return itemsToCreate;
+	}
+
+	public void setItemsToCreate(long itemsToCreate) {
+		this.itemsToCreate = itemsToCreate;
+	}
+
+	public MemcachedCache getCache() {
+		return cache;
+	}
+
+	public void setCache(MemcachedCache cache) {
+		this.cache = cache;
+	}
+
+	@Override
+	public void run() {
+		Random random = new Random();
+
+		for (int i = 0; i < itemsToCreate; i++) {
+			cache.putObject(UUID.randomUUID().toString(), "TEST");
+
+			// Wait between 1 and 10 milliseconds between each insertion
+			try {
+				Thread.sleep(random.nextInt(10) + 1);
+			} catch (InterruptedException e) {
+			}
+		}
+	}
+
+}


### PR DESCRIPTION
Directly related to: https://github.com/mybatis/memcached-cache/issues/11

Ensures that no group value being added to the group is lost.

The part:

 		boolean jobDone = false;

 		while (!jobDone) {
 		...
 		}

Could be improved thought, maybe throwing an exception after a certain number of retries.
