### PR TITLE
Potential fix for code scanning alert no. 3: Use of a potentially broken or risky cryptographic algorithm

### DIFF
--- a/src/main/java/org/mybatis/caches/memcached/StringUtils.java
+++ b/src/main/java/org/mybatis/caches/memcached/StringUtils.java
@@ -37,7 +37,7 @@ public final class StringUtils {
       throw new IllegalArgumentException("data must not be null");
     }
 
-    byte[] bytes = digest("SHA1", data);
+    byte[] bytes = digest("SHA-256", data);
 
     return toHexString(bytes);
   }


### PR DESCRIPTION
Potential fix for [https://github.com/mybatis/memcached-cache/security/code-scanning/3](https://github.com/mybatis/memcached-cache/security/code-scanning/3)

Use a stronger digest algorithm and keep behavior otherwise unchanged (same null checks, same hex encoding output shape).  
Best fix in this file: replace SHA-1 with SHA-256 in `sha1Hex(String data)` by changing the algorithm string passed to `digest(...)`.

Concretely in `src/main/java/org/mybatis/caches/memcached/StringUtils.java`:
- In `sha1Hex`, change:
  - `byte[] bytes = digest("SHA1", data);`
  - to `byte[] bytes = digest("SHA-256", data);`

No new imports, helper methods, or dependencies are required. This preserves functionality (deterministic hash-to-hex) while removing the risky algorithm.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
