### PR TITLE
Potential fix for code scanning alert no. 2: Comparison of narrow type with wide type in loop condition

### DIFF
--- a/src/test/java/org/mybatis/caches/memcached/GroupTestThread.java
+++ b/src/test/java/org/mybatis/caches/memcached/GroupTestThread.java
@@ -53,7 +53,7 @@ public class GroupTestThread extends Thread {
   public void run() {
     Random random = new Random();
 
-    for (int i = 0; i < itemsToCreate; i++) {
+    for (long i = 0; i < itemsToCreate; i++) {
       cache.putObject(UUID.randomUUID().toString(), "TEST");
 
       // Wait between 1 and 10 milliseconds between each insertion


### PR DESCRIPTION
Potential fix for [https://github.com/mybatis/memcached-cache/security/code-scanning/2](https://github.com/mybatis/memcached-cache/security/code-scanning/2)

Use a loop counter type that is at least as wide as the compared bound type.

Best fix (without changing intended behavior): change the `for` loop counter from `int` to `long` in `src/test/java/org/mybatis/caches/memcached/GroupTestThread.java` line 56 region:
- From: `for (int i = 0; i < itemsToCreate; i++) {`
- To: `for (long i = 0; i < itemsToCreate; i++) {`

No new imports, methods, or dependencies are needed. This preserves existing logic while removing the narrow-vs-wide comparison risk.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
