### PR TITLE
Potential fix for code scanning alert no. 13: Inner class could be static

### DIFF
--- a/src/main/java/org/mybatis/caches/memcached/MemcachedClientWrapper.java
+++ b/src/main/java/org/mybatis/caches/memcached/MemcachedClientWrapper.java
@@ -53,7 +53,7 @@ final class MemcachedClientWrapper {
    *
    * @author Weisz, Gustavo E.
    */
-  private class ObjectWithCas {
+  private static class ObjectWithCas {
 
     Object object;
     long cas;


### PR DESCRIPTION
Potential fix for [https://github.com/mybatis/memcached-cache/security/code-scanning/13](https://github.com/mybatis/memcached-cache/security/code-scanning/13)

To fix this, change the nested class declaration from a non-static inner class to a static nested class.

Best minimal fix (no functional change):
- In `src/main/java/org/mybatis/caches/memcached/MemcachedClientWrapper.java`, at the declaration of `ObjectWithCas` (line 56 in the snippet), replace:
  - `private class ObjectWithCas {`
  with:
  - `private static class ObjectWithCas {`

No additional imports, methods, or constructor signature changes are needed because the class does not access any instance members of `MemcachedClientWrapper`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
